### PR TITLE
Generate specific version docs in separate folders

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -2,7 +2,7 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-version="1.0.0.beta2"
+version="1.0.0.beta3"
 locale="en"
 
 main() {
@@ -24,7 +24,7 @@ install_hanami() {
 
 generate_docs() {
   local sources="gems/gems/hanami*/lib/**/*"
-  local target=doc
+  local target="docs/$version"
   local title="Hanami Docs $version"
 
   if [ -d $target ]; then

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- These meta tags come first. -->
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- Use title if it's in the page YAML frontmatter -->
+    <title> </title>
+
+    <!-- Redirect to latest documentation -->
+    <meta http-equiv="refresh" content="0; url=/1.0.0.beta3">
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
From GitHub page help:
> You can configure GitHub Pages to publish your site's source files from `master`, `gh-pages`, or a `/docs` folder on your master branch for Project Pages and other Pages sites that meet certain criteria.

## What I do
Now docs for each version generates in `/docs` folder (it needs for GitHub page). After that, we can change docs for each version in URL (I mean `docs.hanami.com/1.0.0` and `docs.hanami.com/1.1.0`). Also, I created the simple index page with the redirect to specific doc version (latest in my case).

-------------------

Now we can generate docs for each version and work with it.
