### PR TITLE
Fix link to guides in README.

### DIFF
--- a/source/README.md
+++ b/source/README.md
@@ -16,7 +16,7 @@ API documentation for [Hanami](http://hanamirb.org).
     cd bookshelf && bundle
     bundle exec hanami server # visit http://localhost:2300
 
-Please follow along with the [Getting Started guide](http://hanamirb.org/guides/getting-started).
+Please follow along with the [Getting Started guide](http://hanamirb.org/guides/1.2/getting-started).
 
 ## Contact
 


### PR DESCRIPTION
Could also be a missing redirect I imagine? But this just points to the right page.