### PR TITLE
Fix broken 404 link to guides.hanamirb.org

### DIFF
--- a/source/README.md
+++ b/source/README.md
@@ -16,7 +16,7 @@ API documentation for [Hanami](http://hanamirb.org).
     cd bookshelf && bundle
     bundle exec hanami server # visit http://localhost:2300
 
-Please follow along with the [Getting Started guide](http://hanamirb.org/guides/1.2/getting-started).
+Please follow along with the [Getting Started guide](https://guides.hanamirb.org/introduction/getting-started).
 
 ## Contact
 


### PR DESCRIPTION
Add guides subdomain to a broken link to fix https://github.com/hanami/hanami/issues/980