### PR TITLE
Fix Broken Link to guides

### DIFF
--- a/source/README.md
+++ b/source/README.md
@@ -16,7 +16,7 @@ API documentation for [Hanami](http://hanamirb.org).
     cd bookshelf && bundle
     bundle exec hanami server # visit http://localhost:2300
 
-Please follow along with the [Getting Started guide](https://guides.hanamirb.org/v1.3/introduction/getting-started/).
+Please follow along with the [Getting Started guide](https://guides.hanamirb.org/v2.0/introduction/getting-started).
 
 ## Contact
 

--- a/source/README.md
+++ b/source/README.md
@@ -16,7 +16,7 @@ API documentation for [Hanami](http://hanamirb.org).
     cd bookshelf && bundle
     bundle exec hanami server # visit http://localhost:2300
 
-Please follow along with the [Getting Started guide](http://hanamirb.org/guides/1.2/getting-started).
+Please follow along with the [Getting Started guide](https://guides.hanamirb.org/v1.3/introduction/getting-started/).
 
 ## Contact
 

--- a/source/README.md
+++ b/source/README.md
@@ -16,7 +16,7 @@ API documentation for [Hanami](http://hanamirb.org).
     cd bookshelf && bundle
     bundle exec hanami server # visit http://localhost:2300
 
-Please follow along with the [Getting Started guide](https://guides.hanamirb.org/v2.0/introduction/getting-started).
+Please follow along with the [Getting Started guide](https://guides.hanamirb.org/introduction/getting-started).
 
 ## Contact
 


### PR DESCRIPTION
Hey just wanted to fix a link in the docs to the getting started guide. It should work now. Let me know if any changes are needed